### PR TITLE
Allow equal subtitles in the same chapter

### DIFF
--- a/lib/filters/labelify.rb
+++ b/lib/filters/labelify.rb
@@ -162,6 +162,17 @@ def process_title node
     @appendix[i] = appendix
   end
 
+  # Add an incrementing counter at the end of the node ID in case it is not unique
+  while @display_name.has_key?(node[:id])
+    if node[:id].match(/_[0-9]+$/)
+      # Increment the counter
+      node[:id] = node[:id].gsub(/\d+$/,&:next)
+    else
+      # Add the counter
+      node[:id] += "_1"
+    end
+  end
+  # Should now be unique
   if @display_name.has_key?(node[:id])
     raise "Duplicate id: " + node[:id]
   end


### PR DESCRIPTION
This allows to have following structure

```
# Example

## Architecture

### My app

## Implementation

### My app    <--- this wasn't possible before because there already exists a "My app" title on this level.
```